### PR TITLE
Refactor for multiproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     }
 }
 
+apply plugin: 'idea'
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'com.bmuschko.nexus'
@@ -20,19 +21,6 @@ repositories {
     mavenCentral()
 }
 
-// Write the plugin's classpath to a file to share with the tests
-task createClasspathManifest {
-    def outputDir = file("$buildDir/$name")
-
-    inputs.files sourceSets.main.runtimeClasspath
-    outputs.dir outputDir
-
-    doLast {
-        outputDir.mkdirs()
-        file("$outputDir/plugin-classpath.txt").text = sourceSets.main.runtimeClasspath.join("\n")
-    }
-}
-
 dependencies {
     compile gradleApi()
     compile localGroovy()
@@ -40,7 +28,6 @@ dependencies {
     testCompile 'junit:junit:4.10'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'
     testCompile gradleTestKit()
-    testRuntime files(createClasspathManifest)
 }
 
 install {

--- a/src/main/groovy/net/jokubasdargis/buildtimer/BuildTimerPlugin.groovy
+++ b/src/main/groovy/net/jokubasdargis/buildtimer/BuildTimerPlugin.groovy
@@ -5,22 +5,12 @@ import org.gradle.api.Project
 
 class BuildTimerPlugin implements Plugin<Project> {
 
+    private static TimingsListener timingsListener = new TimingsListener()
+
     @Override
     void apply(Project project) {
         project.extensions.create(BuildTimerPluginExtension.NAME, BuildTimerPluginExtension)
-        project.afterEvaluate {
-            addTimingsListener(project)
-        }
+        project.gradle.addListener(timingsListener)
     }
 
-    static TimingsListener addTimingsListener(Project project) {
-        final BuildTimerPluginExtension extension = project.extensions
-                .findByType(BuildTimerPluginExtension);
-        final long reportAbove = extension != null ?
-                extension.reportAbove : BuildTimerPluginExtension.DEFAULT_REPORT_ABOVE;
-        final TimingsListener listener = new TimingsListener(reportAbove);
-        project.gradle.addListener(listener)
-
-        return listener
-    }
 }

--- a/src/main/groovy/net/jokubasdargis/buildtimer/BuildTimerPlugin.groovy
+++ b/src/main/groovy/net/jokubasdargis/buildtimer/BuildTimerPlugin.groovy
@@ -5,12 +5,16 @@ import org.gradle.api.Project
 
 class BuildTimerPlugin implements Plugin<Project> {
 
-    private static TimingsListener timingsListener = new TimingsListener()
+    public static final String TAG = 'taggedByTimerPlugin'
 
     @Override
     void apply(Project project) {
         project.extensions.create(BuildTimerPluginExtension.NAME, BuildTimerPluginExtension)
-        project.gradle.addListener(timingsListener)
+
+        if (project.rootProject.hasProperty(TAG) == false) {
+            project.gradle.addListener(new TimingsListener())
+            project.rootProject.ext[TAG] = true
+        }
     }
 
 }

--- a/src/test/groovy/net/jokubasdargis/buildtimer/BuildTimerPluginBuildTest.groovy
+++ b/src/test/groovy/net/jokubasdargis/buildtimer/BuildTimerPluginBuildTest.groovy
@@ -14,20 +14,15 @@ class BuildTimerPluginBuildTest {
     @Rule public final TemporaryFolder testProjectDir = new TemporaryFolder()
 
     File buildFile
-    List<File> pluginClasspath
 
     @Before
     public void setUp() {
         buildFile = testProjectDir.newFile('build.gradle')
+    }
 
-        def pluginClasspathResource = getClass()
-                .classLoader.findResource("plugin-classpath.txt")
-        if (pluginClasspathResource == null) {
-            throw new IllegalStateException(
-                    "Did not find plugin classpath resource, run `testClasses` build task.")
-        }
-
-        pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
+    private List<File> getPluginClasspath() {
+        System.getProperty("java.class.path").split(File.pathSeparator)
+                .collect { new File(it) }
     }
 
     @Test

--- a/src/test/groovy/net/jokubasdargis/buildtimer/BuildTimerPluginTest.groovy
+++ b/src/test/groovy/net/jokubasdargis/buildtimer/BuildTimerPluginTest.groovy
@@ -1,6 +1,7 @@
 package net.jokubasdargis.buildtimer;
 
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
 
@@ -15,19 +16,29 @@ class BuildTimerPluginTest {
     @Test
     public void setupDefaultTimingsListener() {
         Project project = ProjectBuilder.builder().build()
-        TimingsListener listener = BuildTimerPlugin.addTimingsListener(project)
-        assert listener.reportAbove == BuildTimerPluginExtension.DEFAULT_REPORT_ABOVE
+        TimingsListener listener = BuildTimerPlugin.timingsListener
+
+        Task task = project.tasks.create("task")
+        listener.beforeExecute(task)
+
+        TimingsListener.Timing timing = listener.timings.values().first()
+        timing.getReportAboveForTask() == BuildTimerPluginExtension.DEFAULT_REPORT_ABOVE;
     }
 
     @Test
     public void setupCustomTimingsListener() {
         Project project = ProjectBuilder.builder().build()
+        TimingsListener listener = BuildTimerPlugin.timingsListener
         project.apply plugin: 'net.jokubasdargis.build-timer'
 
         def customTime = 60L
         project.buildTimer.reportAbove = customTime
 
-        TimingsListener listener = BuildTimerPlugin.addTimingsListener(project)
-        assert listener.reportAbove == customTime
+        Task task = project.tasks.create("task")
+        listener.beforeExecute(task)
+
+        TimingsListener.Timing timing = listener.timings.values().first()
+        timing.getReportAboveForTask() == customTime
     }
+
 }

--- a/src/test/groovy/net/jokubasdargis/buildtimer/BuildTimerPluginTest.groovy
+++ b/src/test/groovy/net/jokubasdargis/buildtimer/BuildTimerPluginTest.groovy
@@ -11,12 +11,14 @@ class BuildTimerPluginTest {
     public void pluginApplies() {
         Project project = ProjectBuilder.builder().build()
         project.apply plugin: 'net.jokubasdargis.build-timer'
+
+        assert project.getPluginManager().hasPlugin('net.jokubasdargis.build-timer')
     }
 
     @Test
     public void setupDefaultTimingsListener() {
         Project project = ProjectBuilder.builder().build()
-        TimingsListener listener = BuildTimerPlugin.timingsListener
+        TimingsListener listener = new TimingsListener()
 
         Task task = project.tasks.create("task")
         listener.beforeExecute(task)
@@ -28,7 +30,7 @@ class BuildTimerPluginTest {
     @Test
     public void setupCustomTimingsListener() {
         Project project = ProjectBuilder.builder().build()
-        TimingsListener listener = BuildTimerPlugin.timingsListener
+        TimingsListener listener = new TimingsListener()
         project.apply plugin: 'net.jokubasdargis.build-timer'
 
         def customTime = 60L


### PR DESCRIPTION
First off, awesome plugin!  

The only issue I'm having is that it adds a new listener to project.gradle every time the plugin is applied.  This is fine with a single project but with multiple projects (as in multi-module build), it adds multiple listeners to the same Gradle instance (there's only one Gradle instance for all projects in a given build).  Since the BuildResult passed into buildFinished contains tasks across all projects, it results in the same output being printed out multiple times, once for every module defined.  

I'm not generally a fan of static variables but I can't think of an alternative - Gradle:addListener will not add the same listener twice so only the single listener will ever be added no matter how many projects the plugin is applied.  If you can think of a better solution, let me know and I'll update the PR.
